### PR TITLE
Very minor typo fixed and tab removed

### DIFF
--- a/examples/PS4ReceiveData/PS4ReceiveData.ino
+++ b/examples/PS4ReceiveData/PS4ReceiveData.ino
@@ -91,7 +91,7 @@ void loop()
      if (PS4.data.status.mic)
         Serial.println("The controller has a mic attached");
 
-     Serial.print("Battey Percent : ");
+     Serial.print("Battery Percent : ");
      Serial.println(PS4.data.status.battery, DEC);
 
 		 Serial.println();

--- a/src/ps4_parser.c
+++ b/src/ps4_parser.c
@@ -63,7 +63,7 @@ enum ps4_button_mask {
 
     ps4_button_mask_l1       = 1 << 8,
     ps4_button_mask_r1       = 1 << 9,
-	ps4_button_mask_l2       = 1 << 10,
+    ps4_button_mask_l2       = 1 << 10,
     ps4_button_mask_r2       = 1 << 11,
 
     ps4_button_mask_share    = 1 << 12,


### PR DESCRIPTION
Now that I have your attention... :)

I tried sending you an email on 2/12, but it probably went to spam:
I came across your PS4-esp32 project and am very appreciative that you (and the team) made it open source. I've been looking for a way to implement a generic Bluetooth HID host on ESP32 so I can connect to any Bluetooth gamepad (Xbox One, PS4, etc) and get the button presses. While btstack/BlueKitchen works, it's heavy and it's license has restrictions, so your repo is much better. Supposedly, they are supposed to be adding a Bluetooth classic HID host example to the esp-idf "soon", but that could be a long time, and I'm not sure whether PS4 would work with it since PS4 seems to handle it's controllers in a weird way by getting the console MAC first. However, I can connect the controller to my Android/Pi with no issue, so I suppose there is a way to bypass the pre-defined MAC address way of connecting. Are you looking into doing it that way as well eventually or supporting other controllers?

Feel free to reach out via Discord for faster chats (@Derf#9562) or reply here / to the email.

-Derf